### PR TITLE
feat: polish hero, theme, and icon styling

### DIFF
--- a/src/components/Contact.astro
+++ b/src/components/Contact.astro
@@ -18,15 +18,20 @@ const socialLinks = getSocialLinks(personalData as unknown as Record<string, str
         </p>
         <h2 class="text-3xl sm:text-4xl lg:text-5xl font-bold section-title">Get in touch.</h2>
         <p class="mt-4 text-base max-w-2xl mx-auto" style="color: var(--text-muted);">
-          The best places to find me are LinkedIn and GitHub. Email is currently a placeholder
-          until I replace it with my preferred public address.
+          The best places to find me are LinkedIn and GitHub.
         </p>
       </div>
 
       <div class="contact-grid reveal" style="transition-delay: 0.1s;">
         <a class="contact-card" href="https://www.linkedin.com/in/robertlech" target="_blank" rel="noopener">
           <span class="contact-icon">
-            <iconify-icon icon="simple-icons:linkedin" width="24" height="24" aria-hidden="true" />
+            <iconify-icon
+              icon="simple-icons:linkedin"
+              width="24"
+              height="24"
+              aria-hidden="true"
+              style="color: #0a66c2;"
+            />
           </span>
           <span>
             <strong>LinkedIn</strong>
@@ -36,7 +41,13 @@ const socialLinks = getSocialLinks(personalData as unknown as Record<string, str
 
         <a class="contact-card" href="https://github.com/robert-7" target="_blank" rel="noopener">
           <span class="contact-icon">
-            <iconify-icon icon="simple-icons:github" width="24" height="24" aria-hidden="true" />
+            <iconify-icon
+              icon="simple-icons:github"
+              width="24"
+              height="24"
+              aria-hidden="true"
+              style="color: #181717;"
+            />
           </span>
           <span>
             <strong>GitHub</strong>
@@ -44,36 +55,27 @@ const socialLinks = getSocialLinks(personalData as unknown as Record<string, str
           </span>
         </a>
 
-        <a class="contact-card" href={`mailto:${personalData.email}`}>
-          <span class="contact-icon">
-            <svg fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-              <path
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-                d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"
-              />
-            </svg>
-          </span>
-          <span>
-            <strong>Email</strong>
-            <small>{personalData.email}</small>
-          </span>
-        </a>
-
         <div class="contact-card" aria-label={personalData.location}>
           <span class="contact-icon">
-            <svg fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+            <svg fill="none" viewBox="0 0 24 24" aria-hidden="true">
+              <defs>
+                <linearGradient id="location-pin-gradient" x1="4" y1="3" x2="20" y2="21">
+                  <stop offset="0%" stop-color="#0ea5e9" />
+                  <stop offset="100%" stop-color="#6366f1" />
+                </linearGradient>
+              </defs>
               <path
                 stroke-linecap="round"
                 stroke-linejoin="round"
                 stroke-width="2"
+                stroke="url(#location-pin-gradient)"
                 d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z"
               />
               <path
                 stroke-linecap="round"
                 stroke-linejoin="round"
                 stroke-width="2"
+                stroke="url(#location-pin-gradient)"
                 d="M15 11a3 3 0 11-6 0 3 3 0 016 0z"
               />
             </svg>
@@ -96,7 +98,13 @@ const socialLinks = getSocialLinks(personalData as unknown as Record<string, str
                 class="contact-social-link"
                 aria-label={link.label}
               >
-                <iconify-icon icon={link.icon} width="22" height="22" aria-hidden="true" />
+                <iconify-icon
+                  icon={link.icon}
+                  width="22"
+                  height="22"
+                  aria-hidden="true"
+                  style={link.color ? `color: ${link.color};` : undefined}
+                />
               </a>
             ))}
           </div>

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -58,7 +58,13 @@ const { footerAttribution } = siteData;
               rel="noopener noreferrer"
               aria-label={link.label}
             >
-              <iconify-icon icon={link.icon} width="20" height="20" aria-hidden="true" />
+              <iconify-icon
+                icon={link.icon}
+                width="20"
+                height="20"
+                aria-hidden="true"
+                style={link.color ? `color: ${link.color};` : undefined}
+              />
             </a>
           ))
         }

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -912,13 +912,6 @@ const heroParts = personalData.heroRole.split(' & ');
     color: #2563eb !important;
   }
 
-  @media (max-width: 1023px) {
-    .order-1 {
-      margin-top: -200px;
-      margin-bottom: -200px;
-    }
-  }
-
   @media (max-width: 639px) {
     .project-frame-sizer {
       width: min(90vw, 380px) !important;
@@ -976,6 +969,23 @@ const heroParts = personalData.heroRole.split(' & ');
 
     #home {
       padding-top: 3rem;
+    }
+
+    #home .grid {
+      align-content: start;
+      gap: 2.5rem;
+      min-height: auto;
+      padding-top: 1rem;
+      padding-bottom: 4rem;
+    }
+
+    #home .order-1 {
+      margin-top: 0;
+      margin-bottom: 0;
+    }
+
+    #home .order-2 {
+      margin-top: 0;
     }
   }
 

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -90,7 +90,13 @@ const heroParts = personalData.heroRole.split(' & ');
                 class="hero-social-link"
                 aria-label={link.label}
               >
-                <iconify-icon icon={link.icon} width="24" height="24" aria-hidden="true" />
+                <iconify-icon
+                  icon={link.icon}
+                  width="24"
+                  height="24"
+                  aria-hidden="true"
+                  style={link.color ? `color: ${link.color};` : undefined}
+                />
               </a>
             ))
           }

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -48,7 +48,7 @@ const heroParts = personalData.heroRole.split(' & ');
           Backend systems · Platform reliability
         </p>
 
-        <div class="reveal text-backdrop" style="transition-delay: 0.1s;">
+        <div class="reveal text-backdrop hero-headline-panel" style="transition-delay: 0.1s;">
           <h1 class="font-bold leading-tight" style="font-size: clamp(2.5rem, 5vw, 4.5rem);">
             Hi, I'm<br />
             <span class="gradient-text">{personalData.name}</span>
@@ -69,7 +69,7 @@ const heroParts = personalData.heroRole.split(' & ');
         </div>
 
         <p
-          class="text-base text-slate-400 max-w-lg leading-relaxed reveal text-backdrop"
+          class="text-base text-slate-400 max-w-lg leading-relaxed reveal text-backdrop hero-copy-panel"
           style="transition-delay: 0.2s;"
         >
           {personalData.bio}
@@ -165,12 +165,12 @@ const heroParts = personalData.heroRole.split(' & ');
                         width="450"
                         height="450"
                       />
-                      <div class="absolute bottom-3 left-3 right-3 overflow-hidden">
-                        <div class="bg-slate-950/85 backdrop-blur-md px-3 py-2 border border-white/5">
-                          <p class="text-white font-bold text-sm truncate font-mono">
+                      <div class="hero-slide-caption-wrap absolute bottom-3 left-3 right-3 overflow-hidden">
+                        <div class="hero-slide-caption backdrop-blur-md px-3 py-2 border">
+                          <p class="hero-slide-title font-bold text-sm truncate font-mono">
                             {project.title}
                           </p>
-                          <p style="color: var(--accent);" class="text-xs font-medium truncate">
+                          <p class="hero-slide-company text-xs font-medium truncate">
                             {project.company}
                           </p>
                         </div>
@@ -186,10 +186,11 @@ const heroParts = personalData.heroRole.split(' & ');
                     <button
                       class="slider-dot w-1.5 h-1.5 transition-[background-color,width] duration-300"
                       data-dot={i}
+                      aria-current={i === 0 ? 'true' : 'false'}
                       style={
                         i === 0
-                          ? 'background:#6366f1;width:1.25rem;'
-                          : 'background:rgba(255,255,255,0.25);'
+                          ? 'width:1.25rem;'
+                          : 'width:0.375rem;'
                       }
                       aria-label={`Go to slide ${i + 1}`}
                     />
@@ -281,10 +282,10 @@ const heroParts = personalData.heroRole.split(' & ');
     outline: 2px solid var(--accent);
     outline-offset: 2px;
   }
-  [data-theme='light'] .hero-social-link {
+  :global([data-theme='light']) .hero-social-link {
     color: #475569;
   }
-  [data-theme='light'] .hero-social-link:hover {
+  :global([data-theme='light']) .hero-social-link:hover {
     color: #1e293b;
   }
 
@@ -397,6 +398,27 @@ const heroParts = personalData.heroRole.split(' & ');
     cursor: pointer;
   }
 
+  .hero-slide-caption {
+    background: rgba(2, 6, 23, 0.85);
+    border-color: rgba(255, 255, 255, 0.05);
+  }
+
+  .hero-slide-title {
+    color: #ffffff;
+  }
+
+  .hero-slide-company {
+    color: var(--accent);
+  }
+
+  .slider-dot {
+    background: rgba(255, 255, 255, 0.25);
+  }
+
+  .slider-dot[aria-current='true'] {
+    background: #6366f1;
+  }
+
   .slider-nav-btn {
     position: absolute;
     top: 50%;
@@ -502,6 +524,25 @@ const heroParts = personalData.heroRole.split(' & ');
     transform: translateX(2px);
   }
 
+  :global([data-theme='light']) .slider-nav-btn {
+    background: rgba(255, 255, 255, 0.78);
+    border-color: rgba(37, 99, 235, 0.16);
+    box-shadow:
+      0 10px 28px rgba(37, 99, 235, 0.16),
+      0 1px 0 rgba(255, 255, 255, 0.9) inset;
+    color: #2563eb;
+  }
+
+  :global([data-theme='light']) .slider-nav-btn:hover {
+    background: rgba(239, 246, 255, 0.94);
+    border-color: rgba(14, 165, 233, 0.48);
+    color: #0f172a;
+    box-shadow:
+      0 12px 32px rgba(37, 99, 235, 0.2),
+      0 0 0 1px rgba(14, 165, 233, 0.18),
+      0 1px 0 rgba(255, 255, 255, 0.95) inset;
+  }
+
   .text-backdrop {
     position: relative;
     z-index: 2;
@@ -511,6 +552,64 @@ const heroParts = personalData.heroRole.split(' & ');
     border-radius: 0.6rem;
     padding: 0.75rem 1rem;
     border-left: 2px solid rgba(96, 165, 250, 0.1);
+  }
+
+  :global([data-theme='light']) .text-backdrop {
+    color: #1e293b;
+    background:
+      linear-gradient(135deg, rgba(255, 255, 255, 0.94), rgba(239, 246, 255, 0.82)),
+      repeating-linear-gradient(
+        0deg,
+        rgba(37, 99, 235, 0.035) 0,
+        rgba(37, 99, 235, 0.035) 1px,
+        transparent 1px,
+        transparent 12px
+      );
+    border: 1px solid rgba(37, 99, 235, 0.16);
+    border-left: 4px solid rgba(14, 165, 233, 0.64);
+    box-shadow:
+      0 20px 50px rgba(37, 99, 235, 0.09),
+      inset 0 1px 0 rgba(255, 255, 255, 0.95);
+  }
+
+  :global([data-theme='light']) .hero-headline-panel {
+    border-radius: 0.85rem;
+  }
+
+  :global([data-theme='light']) .hero-headline-panel::after {
+    content: '';
+    position: absolute;
+    right: 1rem;
+    bottom: 0.85rem;
+    width: 5.25rem;
+    height: 0.45rem;
+    background: linear-gradient(90deg, rgba(14, 165, 233, 0.45), rgba(79, 70, 229, 0.65));
+    border-radius: 999px;
+    opacity: 0.75;
+    pointer-events: none;
+  }
+
+  :global([data-theme='light']) .hero-copy-panel {
+    background:
+      linear-gradient(135deg, rgba(255, 255, 255, 0.88), rgba(248, 250, 252, 0.76)),
+      repeating-linear-gradient(
+        90deg,
+        rgba(14, 165, 233, 0.035) 0,
+        rgba(14, 165, 233, 0.035) 1px,
+        transparent 1px,
+        transparent 14px
+      );
+    border-left-color: rgba(79, 70, 229, 0.46);
+    color: #334155;
+    box-shadow: 0 16px 38px rgba(15, 23, 42, 0.08);
+  }
+
+  :global([data-theme='light']) .hero-headline-panel h1 {
+    color: #172033;
+  }
+
+  :global([data-theme='light']) .hero-headline-panel h2 {
+    color: #475569;
   }
 
   .project-frame-outer {
@@ -677,6 +776,142 @@ const heroParts = personalData.heroRole.split(' & ');
       inset 1px 1px 0 rgba(99, 153, 255, 0.06);
   }
 
+  :global([data-theme='light']) .project-frame {
+    background:
+      linear-gradient(135deg, rgba(255, 255, 255, 0.92), rgba(226, 232, 240, 0.78)),
+      repeating-linear-gradient(
+        0deg,
+        rgba(37, 99, 235, 0.045) 0,
+        rgba(37, 99, 235, 0.045) 1px,
+        transparent 1px,
+        transparent 12px
+      );
+    outline: 1px solid rgba(30, 64, 175, 0.28);
+    box-shadow:
+      0 24px 55px rgba(15, 23, 42, 0.18),
+      0 0 0 1px rgba(255, 255, 255, 0.74) inset,
+      inset 1px 1px 0 rgba(255, 255, 255, 0.88),
+      inset -1px -1px 0 rgba(37, 99, 235, 0.08);
+  }
+
+  :global([data-theme='light']) .pf-header {
+    background:
+      linear-gradient(180deg, rgba(248, 250, 252, 0.96), rgba(219, 234, 254, 0.9)),
+      linear-gradient(90deg, rgba(14, 165, 233, 0.18), transparent 58%);
+    border-color:
+      rgba(255, 255, 255, 0.92)
+      rgba(37, 99, 235, 0.28)
+      rgba(37, 99, 235, 0.32)
+      rgba(255, 255, 255, 0.92);
+  }
+
+  :global([data-theme='light']) .pf-title {
+    color: #334155;
+    text-shadow: none;
+  }
+
+  :global([data-theme='light']) .pf-btn {
+    background-color: rgba(255, 255, 255, 0.74);
+    border-color:
+      rgba(255, 255, 255, 0.94)
+      rgba(37, 99, 235, 0.3)
+      rgba(37, 99, 235, 0.34)
+      rgba(255, 255, 255, 0.94);
+  }
+
+  :global([data-theme='light']) .pf-btn:active {
+    border-color:
+      rgba(37, 99, 235, 0.34)
+      rgba(255, 255, 255, 0.94)
+      rgba(255, 255, 255, 0.94)
+      rgba(37, 99, 235, 0.3);
+  }
+
+  :global([data-theme='light']) .pf-btn:hover {
+    background-color: rgba(239, 246, 255, 0.94);
+  }
+
+  :global([data-theme='light']) .pf-btn-icon {
+    color: #2563eb;
+  }
+
+  :global([data-theme='light']) .pf-btn:hover .pf-btn-icon {
+    color: #0f172a;
+  }
+
+  :global([data-theme='light']) .pf-body {
+    background:
+      linear-gradient(135deg, rgba(248, 250, 252, 0.96), rgba(219, 234, 254, 0.72)),
+      repeating-linear-gradient(
+        90deg,
+        rgba(37, 99, 235, 0.04) 0,
+        rgba(37, 99, 235, 0.04) 1px,
+        transparent 1px,
+        transparent 14px
+      );
+    border-color:
+      rgba(37, 99, 235, 0.34)
+      rgba(255, 255, 255, 0.72)
+      rgba(255, 255, 255, 0.72)
+      rgba(37, 99, 235, 0.34);
+  }
+
+  :global([data-theme='light']) .hero-slide {
+    padding: 0.45rem;
+  }
+
+  :global([data-theme='light']) .hero-slide img {
+    border: 1px solid rgba(37, 99, 235, 0.14);
+    background: #ffffff;
+    box-shadow: 0 10px 28px rgba(15, 23, 42, 0.12);
+  }
+
+  :global([data-theme='light']) .hero-slide-caption-wrap {
+    bottom: 0.85rem;
+    left: 0.85rem;
+    right: 0.85rem;
+  }
+
+  :global([data-theme='light']) .hero-slide-caption {
+    background:
+      linear-gradient(135deg, rgba(255, 255, 255, 0.9), rgba(239, 246, 255, 0.78));
+    border-color: rgba(37, 99, 235, 0.16);
+    box-shadow:
+      0 12px 28px rgba(15, 23, 42, 0.12),
+      inset 0 1px 0 rgba(255, 255, 255, 0.95);
+  }
+
+  :global([data-theme='light']) .hero-slide-title {
+    color: #1e293b;
+  }
+
+  :global([data-theme='light']) .hero-slide-company {
+    color: #2563eb;
+  }
+
+  :global([data-theme='light']) .slider-dot {
+    background: rgba(37, 99, 235, 0.22);
+  }
+
+  :global([data-theme='light']) .slider-dot[aria-current='true'] {
+    background: #2563eb;
+  }
+
+  :global([data-theme='light']) .pf-badge,
+  :global([data-theme='light']) .pf-counter {
+    background:
+      linear-gradient(135deg, rgba(255, 255, 255, 0.92), rgba(219, 234, 254, 0.82));
+    outline: 1px solid rgba(30, 64, 175, 0.24);
+    box-shadow:
+      0 14px 28px rgba(15, 23, 42, 0.18),
+      inset 1px 1px 0 rgba(255, 255, 255, 0.88);
+  }
+
+  :global([data-theme='light']) .pf-badge,
+  :global([data-theme='light']) .slider-counter {
+    color: #2563eb !important;
+  }
+
   @media (max-width: 1023px) {
     .order-1 {
       margin-top: -200px;
@@ -744,7 +979,7 @@ const heroParts = personalData.heroRole.split(' & ');
     }
   }
 
-  [data-theme='light'] .gradient-text {
+  :global([data-theme='light']) .gradient-text {
     background: linear-gradient(90deg, #716ae3, #4984a2, #716ae3);
     background-size: 200% auto;
     -webkit-background-clip: text;
@@ -798,11 +1033,10 @@ const heroParts = personalData.heroRole.split(' & ');
     badges[current].style.transform = 'scale(1)';
 
     dots.forEach((d, i) => {
+      d.setAttribute('aria-current', i === current ? 'true' : 'false');
       if (i === current) {
-        d.style.background = '#6366f1';
         d.style.width = '1.25rem';
       } else {
-        d.style.background = 'rgba(255,255,255,0.25)';
         d.style.width = '0.375rem';
       }
     });

--- a/src/data/menu.json
+++ b/src/data/menu.json
@@ -40,7 +40,7 @@
       "label": "Contact",
       "shortLabel": "Contact",
       "href": "#contact",
-      "desc": "LinkedIn, GitHub, location, and email"
+      "desc": "LinkedIn, GitHub, and location"
     }
   ]
 }

--- a/src/lib/socialLinks.ts
+++ b/src/lib/socialLinks.ts
@@ -6,15 +6,22 @@ interface SocialConfig {
   label: string;
   urlTemplate: string;
   icon: string;
+  color?: string;
 }
 
 // {v} in urlTemplate is replaced with the raw handle value from personal.json at call time.
 const SOCIAL_CONFIG: Record<string, SocialConfig> = {
-  github: { label: 'GitHub', urlTemplate: 'https://github.com/{v}', icon: 'simple-icons:github' },
+  github: {
+    label: 'GitHub',
+    urlTemplate: 'https://github.com/{v}',
+    icon: 'simple-icons:github',
+    color: '#181717',
+  },
   linkedin: {
     label: 'LinkedIn',
     urlTemplate: 'https://linkedin.com/in/{v}',
     icon: 'simple-icons:linkedin',
+    color: '#0A66C2',
   },
   gitlab: { label: 'GitLab', urlTemplate: 'https://gitlab.com/{v}', icon: 'simple-icons:gitlab' },
   twitter: { label: 'X (Twitter)', urlTemplate: 'https://x.com/{v}', icon: 'simple-icons:x' },
@@ -92,6 +99,7 @@ export interface SocialLink {
   label: string;
   url: string;
   icon: string;
+  color?: string;
 }
 
 // filterKeys lets callers request a subset in a specific order (e.g. heroSocialLinks in personal.json).
@@ -111,6 +119,7 @@ export function getSocialLinks(personal: PersonalData, filterKeys?: string[]): S
         label: config.label,
         url: config.urlTemplate.replace('{v}', handle),
         icon: config.icon,
+        color: config.color,
       };
     });
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -459,14 +459,6 @@ body.page-hidden * {
   box-shadow: 0 8px 32px #00000040;
 }
 
-[data-theme="light"] .text-backdrop h1 {
-  color: var(--bg-input);
-}
-
-[data-theme="light"] p.text-base.text-slate-400.text-backdrop {
-  color: var(--bg-nav);
-}
-
 /* ===== PRINT / RESUME ===== */
 
 .print-only {


### PR DESCRIPTION
## What changed
- Refined the social/icon coloring across the site so the header, footer, and contact links share the intended palette.
- Improved the light theme visuals in the hero so it feels more polished and consistent with the rest of the page.
- Fixed the mobile hero layout so the featured projects window no longer overlaps the intro content.

## Why
This branch is a small UI polish pass across the homepage, focused on making the first screen read better on mobile and making the theme/icon styling feel more intentional in both light and dark modes.

## Result
The homepage now has cleaner spacing on phones, more consistent icon colors, and a nicer light-theme presentation without changing the overall structure of the site.